### PR TITLE
Add `EpollSystem` implementation for JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ ThisBuild / githubWorkflowPublishPreamble +=
 val ceVersion = "3.6-e9aeb8c"
 val fs2Version = "3.9.1"
 val jnrFfiVersion = "2.2.14"
+val jnrConstatsVersion = "0.10.4"
 val munitCEVersion = "2.0.0-M3"
 
 lazy val root = project.in(file(".")).aggregate(epoll).enablePlugins(NoPublishPlugin)
@@ -37,6 +38,7 @@ lazy val epoll = project
       "org.typelevel" %% "cats-effect" % ceVersion,
       "co.fs2" %% "fs2-io" % fs2Version,
       "com.github.jnr" % "jnr-ffi" % jnrFfiVersion,
+      "com.github.jnr" % "jnr-constants" % jnrConstatsVersion,
       "org.typelevel" %% "munit-cats-effect" % munitCEVersion % Test
     ),
     Test / testOptions += Tests.Argument("+l")

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ ThisBuild / githubWorkflowPublishPreamble +=
 val ceVersion = "3.6-e9aeb8c"
 val fs2Version = "3.9.2"
 val jnrFfiVersion = "2.2.15"
-val jnrConstatsVersion = "0.10.4"
+val jnrConstantsVersion = "0.10.4"
 val munitCEVersion = "2.0.0-M3"
 
 lazy val root = project.in(file(".")).aggregate(epoll).enablePlugins(NoPublishPlugin)
@@ -38,7 +38,7 @@ lazy val epoll = project
       "org.typelevel" %% "cats-effect" % ceVersion,
       "co.fs2" %% "fs2-io" % fs2Version,
       "com.github.jnr" % "jnr-ffi" % jnrFfiVersion,
-      "com.github.jnr" % "jnr-constants" % jnrConstatsVersion,
+      "com.github.jnr" % "jnr-constants" % jnrConstantsVersion,
       "org.typelevel" %% "munit-cats-effect" % munitCEVersion % Test
     ),
     Test / testOptions += Tests.Argument("+l")

--- a/epoll/src/main/scala/cats/effect/FileDescriptorPoller.scala
+++ b/epoll/src/main/scala/cats/effect/FileDescriptorPoller.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is ported from https://github.com/typelevel/cats-effect/blob/fdb2a3e468a67c51a513aec758fed11caa44a405/core/native/src/main/scala/cats/effect/FileDescriptorPoller.scala
+package cats.effect
+
+import cats.syntax.all._
+
+trait FileDescriptorPoller {
+
+  /** Registers a file descriptor with the poller and monitors read- and/or write-ready events.
+    */
+  def registerFileDescriptor(
+      fileDescriptor: Int,
+      monitorReadReady: Boolean,
+      monitorWriteReady: Boolean
+  ): Resource[IO, FileDescriptorPollHandle]
+
+}
+
+object FileDescriptorPoller {
+  def find: IO[Option[FileDescriptorPoller]] =
+    IO.pollers.map(_.collectFirst { case poller: FileDescriptorPoller => poller })
+
+  def get = find.flatMap(
+    _.liftTo[IO](new RuntimeException("No FileDescriptorPoller installed in this IORuntime"))
+  )
+}
+
+trait FileDescriptorPollHandle {
+
+  /** Recursively invokes `f` until it is no longer blocked. Typically `f` will call `read` or
+    * `recv` on the file descriptor.
+    *   - If `f` fails because the file descriptor is blocked, then it should return `Left[A]`.
+    *     Then `f` will be invoked again with `A` at a later point, when the file handle is ready
+    *     for reading.
+    *   - If `f` is successful, then it should return a `Right[B]`. The `IO` returned from this
+    *     method will complete with `B`.
+    */
+  def pollReadRec[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B]
+
+  /** Recursively invokes `f` until it is no longer blocked. Typically `f` will call `write` or
+    * `send` on the file descriptor.
+    *   - If `f` fails because the file descriptor is blocked, then it should return `Left[A]`.
+    *     Then `f` will be invoked again with `A` at a later point, when the file handle is ready
+    *     for writing.
+    *   - If `f` is successful, then it should return a `Right[B]`. The `IO` returned from this
+    *     method will complete with `B`.
+    */
+  def pollWriteRec[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B]
+
+}

--- a/epoll/src/main/scala/cats/effect/FileDescriptorPoller.scala
+++ b/epoll/src/main/scala/cats/effect/FileDescriptorPoller.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// This file is ported from https://github.com/typelevel/cats-effect/blob/fdb2a3e468a67c51a513aec758fed11caa44a405/core/native/src/main/scala/cats/effect/FileDescriptorPoller.scala
 package cats.effect
 
 import cats.syntax.all._

--- a/epoll/src/main/scala/fs2/io/epoll/EpollApp.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/EpollApp.scala
@@ -17,10 +17,11 @@
 package fs2.io.epoll
 
 import cats.effect.IOApp
+import cats.effect.unsafe.PollingSystem
 import fs2.io.epoll.unsafe.EpollSystem
 
 trait EpollApp extends IOApp {
-  override protected final def pollingSystem = EpollSystem
+  override protected final def pollingSystem: PollingSystem = EpollSystem
 }
 
 object EpollApp {

--- a/epoll/src/main/scala/fs2/io/epoll/EpollApp.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/EpollApp.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.io.epoll
+
+import cats.effect.IOApp
+import fs2.io.epoll.unsafe.EpollSystem
+
+trait EpollApp extends IOApp {
+  override protected final def pollingSystem = EpollSystem
+}
+
+object EpollApp {
+  trait Simple extends IOApp.Simple with EpollApp
+}

--- a/epoll/src/main/scala/fs2/io/epoll/FileDescriptorPoller.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/FileDescriptorPoller.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package cats.effect
+package fs2.io.epoll
 
+import cats.effect.{Resource, IO}
 import cats.syntax.all._
 
 trait FileDescriptorPoller {

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.io.epoll
+package unsafe
+
+import cats.effect.unsafe.PollingSystem
+
+object EpollSystem extends PollingSystem {
+  import epoll._
+  import libc._
+
+  def close(): Unit = ???
+
+  def makeApi(register: (Poller => Unit) => Unit): Api = ???
+
+  def makePoller(): Poller = ???
+
+  def closePoller(poller: Poller): Unit = ???
+
+  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = ???
+
+  def needsPoll(poller: Poller): Boolean = ???
+
+  def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ???
+
+  private object epoll {
+    final val EPOLL_CTL_ADD = 1
+    final val EPOLL_CTL_DEL = 2
+    final val EPOLL_CTL_MOD = 3
+
+    final val EPOLLIN = 0x001
+    final val EPOLLOUT = 0x004
+    final val EPOLLONESHOT = 1 << 30
+    final val EPOLLET = 1 << 31
+  }
+}

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -17,10 +17,12 @@
 package fs2.io.epoll
 package unsafe
 
-import cats.effect.{IO, Resource, FileDescriptorPoller, FileDescriptorPollHandle}
+import cats.effect.{IO, Resource}
 import cats.effect.std.Mutex
 import cats.syntax.all._
 import cats.effect.unsafe.PollingSystem
+
+import fs2.io.epoll.{FileDescriptorPoller, FileDescriptorPollHandle}
 
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -54,6 +54,15 @@ object EpollSystem extends PollingSystem {
     if (evfd == -1)
       throw new IOException(strerror(errno()))
 
+    val event = EpollEvent(
+      EPOLLIN | EPOLLOUT,
+      evfd.toLong,
+      globalRuntime
+    )
+
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, evfd, event) != 0)
+      throw new IOException(strerror(errno()))
+
     new Poller(epfd, evfd)
   }
 
@@ -221,8 +230,6 @@ object EpollSystem extends PollingSystem {
 
             i += 1
           }
-        } else if (errno() != Errno.EINTR.intValue()) { // spurious wake-up by signal
-          throw new IOException(strerror(errno()))
         }
 
         if (triggeredEvents >= MaxEvents)

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -84,11 +84,11 @@ object EpollSystem extends PollingSystem {
       readMutex: Mutex[IO],
       writeMutex: Mutex[IO]
   ) extends FileDescriptorPollHandle {
-    private[this] var readReadyCounter = 0
-    private[this] var readCallback: Either[Throwable, Int] => Unit = null
+    @volatile private[this] var readReadyCounter = 0
+    @volatile private[this] var readCallback: Either[Throwable, Int] => Unit = null
 
-    private[this] var writeReadyCounter = 0
-    private[this] var writeCallback: Either[Throwable, Int] => Unit = null
+    @volatile private[this] var writeReadyCounter = 0
+    @volatile private[this] var writeCallback: Either[Throwable, Int] => Unit = null
 
     def notify(events: Int): Unit = {
       if ((events & EPOLLIN) != 0) {

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -223,7 +223,7 @@ object EpollSystem extends PollingSystem {
         cb: Either[Throwable, (PollHandle, IO[Unit])] => Unit
     ): Unit = {
       val events = (EPOLLET | (if (reads) EPOLLIN else 0) | (if (writes) EPOLLOUT else 0)).toInt
-      val data = (System.identityHashCode(handle).toLong << 32) | fd
+      val data = fd.toLong
       val event = EpollEvent(events, data, globalRuntime)
 
       val result =

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -17,25 +17,149 @@
 package fs2.io.epoll
 package unsafe
 
+import cats.effect.{IO, Resource, FileDescriptorPoller, FileDescriptorPollHandle}
+import cats.effect.std.Mutex
+import cats.syntax.all._
 import cats.effect.unsafe.PollingSystem
+
+import java.io.IOException
+import java.util.{Collections, IdentityHashMap, Set}
 
 object EpollSystem extends PollingSystem {
   import epoll._
-  import libc._
+  import libc.jnr._
 
-  def close(): Unit = ???
+  type Api = FileDescriptorPoller
 
-  def makeApi(register: (Poller => Unit) => Unit): Api = ???
+  def close(): Unit = ()
 
-  def makePoller(): Poller = ???
+  def makeApi(register: (Poller => Unit) => Unit): Api =
+    new FileDescriptorPollerImpl(register)
 
-  def closePoller(poller: Poller): Unit = ???
+  def makePoller(): Poller = {
+    val fd = epoll_create1(0)
+    if (fd == -1)
+      throw new IOException(strerror(errno()))
+    new Poller(fd)
+  }
 
-  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean = ???
+  def closePoller(poller: Poller): Unit = poller.close()
 
-  def needsPoll(poller: Poller): Boolean = ???
+  def poll(poller: Poller, nanos: Long, reportFailure: Throwable => Unit): Boolean =
+    poller.poll(nanos)
 
-  def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ???
+  def needsPoll(poller: Poller): Boolean = poller.needsPoll()
+
+  def interrupt(targetThread: Thread, targetPoller: Poller): Unit = ()
+
+  private final class FileDescriptorPollerImpl private[EpollSystem] (
+      register: (Poller => Unit) => Unit
+  ) extends FileDescriptorPoller {
+    def registerFileDescriptor(
+        fd: Int,
+        reads: Boolean,
+        writes: Boolean
+    ): Resource[IO, FileDescriptorPollHandle] =
+      Resource {
+        (Mutex[IO], Mutex[IO]).flatMapN { (readMutex, writeMutex) =>
+          IO.async_[(PollHandle, IO[Unit])] { cb =>
+            register { epoll =>
+              val handle = new PollHandle(readMutex, writeMutex)
+              epoll.register(fd, reads, writes, handle, cb)
+            }
+          }
+        }
+      }
+  }
+
+  private final class PollHandle(
+      readMutex: Mutex[IO],
+      writeMutex: Mutex[IO]
+  ) extends FileDescriptorPollHandle {
+    private[this] var readReadyCounter = 0
+    private[this] var readCallback: Either[Throwable, Int] => Unit = null
+
+    private[this] var writeReadyCounter = 0
+    private[this] var writeCallback: Either[Throwable, Int] => Unit = null
+
+    def pollReadRec[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B] =
+      readMutex.lock.surround {
+        def go(a: A, before: Int): IO[B] =
+          f(a).flatMap {
+            case Left(a) =>
+              IO(readReadyCounter).flatMap { after =>
+                if (before != after)
+                  // there was a read-ready notification since we started, try again immediately
+                  go(a, after)
+                else
+                  IO.asyncCheckAttempt[Int] { cb =>
+                    IO {
+                      readCallback = cb
+                      // check again before we suspend
+                      val now = readReadyCounter
+                      if (now != before) {
+                        readCallback = null
+                        Right(now)
+                      } else Left(Some(IO(this.readCallback = null)))
+                    }
+                  }.flatMap(go(a, _))
+              }
+            case Right(b) => IO.pure(b)
+          }
+
+        IO(readReadyCounter).flatMap(go(a, _))
+      }
+
+    def pollWriteRec[A, B](a: A)(f: A => IO[Either[A, B]]): IO[B] =
+      writeMutex.lock.surround {
+        def go(a: A, before: Int): IO[B] =
+          f(a).flatMap {
+            case Left(a) =>
+              IO(writeReadyCounter).flatMap { after =>
+                if (before != after)
+                  // there was a write-ready notification since we started, try again immediately
+                  go(a, after)
+                else
+                  IO.asyncCheckAttempt[Int] { cb =>
+                    IO {
+                      writeCallback = cb
+                      // check again before we suspend
+                      val now = writeReadyCounter
+                      if (now != before) {
+                        writeCallback = null
+                        Right(now)
+                      } else Left(Some(IO(this.writeCallback = null)))
+                    }
+                  }.flatMap(go(a, _))
+              }
+            case Right(b) => IO.pure(b)
+          }
+
+        IO(writeReadyCounter).flatMap(go(a, _))
+      }
+  }
+
+  final class Poller private[EpollSystem] (epfd: Int) {
+
+    private[this] val handles: Set[PollHandle] =
+      Collections.newSetFromMap(new IdentityHashMap)
+
+    private[EpollSystem] def close(): Unit =
+      if (libc.jnr.close(epfd) != 0)
+        throw new IOException(strerror(errno()))
+
+    private[EpollSystem] def poll(timeout: Long): Boolean = ???
+
+    private[EpollSystem] def needsPoll(): Boolean = !handles.isEmpty()
+
+    private[EpollSystem] def register(
+        fd: Int,
+        reads: Boolean,
+        writes: Boolean,
+        handle: PollHandle,
+        cb: Either[Throwable, (PollHandle, IO[Unit])] => Unit
+    ): Unit = ???
+  }
 
   private object epoll {
     final val EPOLL_CTL_ADD = 1

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -26,7 +26,6 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
 import jnr.ffi.Memory;
-import jnr.constants.platform.Errno;
 
 import scala.annotation.tailrec
 

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/EpollSystem.scala
@@ -50,7 +50,7 @@ object EpollSystem extends PollingSystem {
     if (epfd == -1)
       throw new IOException(strerror(errno()))
 
-    val evfd = libc.jnr.eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK)
+    val evfd = libc.jnr.eventfd(0, EFD_NONBLOCK)
     if (evfd == -1)
       throw new IOException(strerror(errno()))
 

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
@@ -91,6 +91,8 @@ private[epoll] object libc {
       def errno(): Int
       def strerror(errnum: Int): String
       def close(fd: Int): Int
+      def eventfd(initval: Int, flags: Int): Int
+      def write(fd: Int, buf: Pointer, count: Long): Long
     }
 
     def epoll_create1(flags: Int): Int = libc.epoll_create1(flags)
@@ -101,5 +103,7 @@ private[epoll] object libc {
     def errno(): Int = LastError.getLastError(globalRuntime)
     def strerror(errnum: Int): String = libc.strerror(errnum)
     def close(fd: Int): Int = libc.close(fd)
+    def eventfd(initval: Int, flags: Int): Int = libc.eventfd(initval, flags)
+    def write(fd: Int, buf: Pointer, count: Long): Long = libc.write(fd, buf, count)
   }
 }

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.io.epoll
+package unsafe
+
+import jnr.ffi.{LibraryLoader, Platform, Pointer}
+
+private[epoll] object libc {
+
+  trait jnrLibCInterface {
+    def epoll_create1(flags: Int): Int
+
+    def epoll_ctl(epfd: Int, op: Int, fd: Int, event: Pointer): Int
+
+    def epoll_wait(epfd: Int, events: Pointer, maxevents: Int, timeout: Int): Int
+  }
+
+  lazy val libc = LibraryLoader
+    .create(classOf[jnrLibCInterface])
+    .load(Platform.getNativePlatform().getStandardCLibraryName())
+}

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
@@ -17,46 +17,88 @@
 package fs2.io.epoll
 package unsafe
 
-import jnr.ffi.{LibraryLoader, Platform, Pointer, Runtime, LastError}
-
-sealed trait libcFFIInterface {
-  def epoll_create1(flags: Int): Int
-
-  def epoll_ctl(epfd: Int, op: Int, fd: Int, event: Pointer): Int
-
-  def epoll_wait(epfd: Int, events: Pointer, maxevents: Int, timeout: Int): Int
-
-  def errno(): Int
-
-  def strerror(errnum: Int): String
-
-  def close(fd: Int): Int
-}
+import jnr.ffi.{LibraryLoader, Platform, Pointer, Struct, Runtime, LastError}
 
 private[epoll] object libc {
 
-  object jnr extends libcFFIInterface {
+  object jnr {
+    lazy val globalRuntime = Runtime.getSystemRuntime
+
+    private lazy val libc = LibraryLoader
+      .create(classOf[jnrLibcFFIInterface])
+      .load(Platform.getNativePlatform().getStandardCLibraryName())
+
+    /*
+     *  epoll_event layout
+     *
+     *  +---------------------+---------------------+---------------------+
+     *  |       events        |       padding       |       data          |
+     *  |       32bit         |       32bit         |       64bit         |
+     *  +---------------------+---------------------+---------------------+
+     *  Total size: 16 bytes
+     */
+    final class EpollEvent(runtime: Runtime) extends Struct(runtime) {
+      final private val _events: Unsigned32 = new Unsigned32()
+      final private val _data: Unsigned64 = new Unsigned64()
+
+      final val events: Int = _events.get().toInt
+      final val data: Long = _data.get()
+    }
+
+    object EpollEvent {
+      final val CStructSize: Int = 16
+
+      def apply(events: Int, data: Long, runtime: Runtime): EpollEvent = {
+        val ev = new EpollEvent(runtime)
+        ev._events.set(events.toLong)
+        ev._data.set(data)
+        ev
+      }
+
+      def apply(ptr: Pointer, offset: Long, runtime: Runtime): EpollEvent = {
+        val dest = Array.emptyByteArray
+        ptr.get(
+          offset,
+          dest,
+          0,
+          CStructSize
+        )
+
+        val (eventField, dataField) = dest.splitAt(EpollEvent.CStructSize / 2)
+        val event =
+          eventField
+            .take(4)
+            .foldLeft(0L)((acc, b) => (acc << 8) | (b & 0xff))
+
+        val data =
+          dataField
+            .take(8)
+            .foldLeft(0L)((acc, b) => (acc << 8) | (b & 0xff))
+
+        val epollEvent = new EpollEvent(runtime)
+
+        epollEvent._data.set(data)
+        epollEvent._events.set(event)
+
+        epollEvent
+      }
+    }
+
     private trait jnrLibcFFIInterface {
       def epoll_create1(flags: Int): Int
-      def epoll_ctl(epfd: Int, op: Int, fd: Int, event: Pointer): Int
+      def epoll_ctl(epfd: Int, op: Int, fd: Int, event: EpollEvent): Int
       def epoll_wait(epfd: Int, events: Pointer, maxevents: Int, timeout: Int): Int
       def errno(): Int
       def strerror(errnum: Int): String
       def close(fd: Int): Int
     }
 
-    private lazy val libc = LibraryLoader
-      .create(classOf[jnrLibcFFIInterface])
-      .load(Platform.getNativePlatform().getStandardCLibraryName())
-
-    private lazy val runtime = Runtime.getSystemRuntime
-
     def epoll_create1(flags: Int): Int = libc.epoll_create1(flags)
-    def epoll_ctl(epfd: Int, op: Int, fd: Int, event: Pointer): Int =
+    def epoll_ctl(epfd: Int, op: Int, fd: Int, event: EpollEvent): Int =
       libc.epoll_ctl(epfd, op, fd, event)
     def epoll_wait(epfd: Int, events: Pointer, maxevents: Int, timeout: Int): Int =
       libc.epoll_wait(epfd, events, maxevents, timeout)
-    def errno(): Int = LastError.getLastError(runtime)
+    def errno(): Int = LastError.getLastError(globalRuntime)
     def strerror(errnum: Int): String = libc.strerror(errnum)
     def close(fd: Int): Int = libc.close(fd)
   }

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
@@ -56,7 +56,7 @@ private[epoll] object libc {
       }
 
       def apply(ptr: Pointer, offset: Long, runtime: Runtime): EpollEvent = {
-        val dest = Array.emptyByteArray
+        val dest = new Array[Int](CStructSize)
         ptr.get(
           offset,
           dest,

--- a/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
+++ b/epoll/src/main/scala/fs2/io/epoll/unsafe/libc.scala
@@ -17,7 +17,7 @@
 package fs2.io.epoll
 package unsafe
 
-import jnr.ffi.{LibraryLoader, Platform, Pointer, Struct, Runtime, LastError}
+import jnr.ffi.{LibraryLoader, Platform, Pointer, Struct, Runtime, LastError, Memory}
 
 private[epoll] object libc {
 
@@ -93,6 +93,9 @@ private[epoll] object libc {
       def close(fd: Int): Int
       def eventfd(initval: Int, flags: Int): Int
       def write(fd: Int, buf: Pointer, count: Long): Long
+      def read(fd: Int, buf: Pointer, count: Long): Long
+      def pipe(pipefd: Array[Int]): Int
+      def fcntl(fd: Int, cmd1: Int, cmd2: Int): Int
     }
 
     def epoll_create1(flags: Int): Int = libc.epoll_create1(flags)
@@ -105,5 +108,18 @@ private[epoll] object libc {
     def close(fd: Int): Int = libc.close(fd)
     def eventfd(initval: Int, flags: Int): Int = libc.eventfd(initval, flags)
     def write(fd: Int, buf: Pointer, count: Long): Long = libc.write(fd, buf, count)
+    def read(fd: Int, buf: Pointer, count: Long): Long = libc.read(fd, buf, count)
+    def pipe(pipefd: Array[Int]): Int = libc.pipe(pipefd)
+    def fcntl(fd: Int, cmd1: Int, cmd2: Int): Int = libc.fcntl(fd, cmd1, cmd2)
+
+    def byteToPtr(bytes: Array[Byte], offset: Int): Pointer =
+      byteToPtr(bytes, bytes.length, offset)
+
+    def byteToPtr(bytes: Array[Byte], size: Int, offset: Int): Pointer = {
+      val buf = Memory
+        .allocate(globalRuntime, size)
+      buf.put(offset, bytes, 0, size)
+      buf
+    }
   }
 }

--- a/epoll/src/test/scala/fs2/io/epoll/EpollSuite.scala
+++ b/epoll/src/test/scala/fs2/io/epoll/EpollSuite.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.io.epoll
+
+import cats.effect.unsafe.IORuntimeBuilder
+import fs2.io.epoll.unsafe.EpollSystem
+import munit.CatsEffectSuite
+
+abstract class EpollSuite extends CatsEffectSuite {
+
+  override lazy val munitIORuntime =
+    IORuntimeBuilder()
+      .setPollingSystem(EpollSystem)
+      .build()
+}

--- a/epoll/src/test/scala/fs2/io/epoll/EpollSuite.scala
+++ b/epoll/src/test/scala/fs2/io/epoll/EpollSuite.scala
@@ -19,6 +19,7 @@ package fs2.io.epoll
 import cats.effect.unsafe.IORuntimeBuilder
 import fs2.io.epoll.unsafe.EpollSystem
 import munit.CatsEffectSuite
+import scala.concurrent.duration._
 
 abstract class EpollSuite extends CatsEffectSuite {
 
@@ -26,4 +27,5 @@ abstract class EpollSuite extends CatsEffectSuite {
     IORuntimeBuilder()
       .setPollingSystem(EpollSystem)
       .build()
+  override def munitIOTimeout: Duration = 20.second
 }

--- a/epoll/src/test/scala/fs2/io/epoll/EpollSystemSuite.scala
+++ b/epoll/src/test/scala/fs2/io/epoll/EpollSystemSuite.scala
@@ -17,9 +17,9 @@
 package fs2.io.epoll
 
 import cats.effect.IO
-import munit.CatsEffectSuite
 
-class EpollSystemSuite extends CatsEffectSuite {
+class EpollSystemSuite extends EpollSuite {
+
   test("sample suite") {
     IO(42).assertEquals(42)
   }

--- a/epoll/src/test/scala/fs2/io/epoll/EpollSystemSuite.scala
+++ b/epoll/src/test/scala/fs2/io/epoll/EpollSystemSuite.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.io.epoll
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class EpollSystemSuite extends CatsEffectSuite {
+  test("sample suite") {
+    IO(42).assertEquals(42)
+  }
+}

--- a/epoll/src/test/scala/fs2/io/epoll/EpollSystemSuite.scala
+++ b/epoll/src/test/scala/fs2/io/epoll/EpollSystemSuite.scala
@@ -16,11 +16,109 @@
 
 package fs2.io.epoll
 
-import cats.effect.IO
+import cats.effect.{IO, Resource}
+import cats.syntax.all._
+
+import fs2.io.epoll.unsafe.EpollSystem._
+import fs2.io.epoll.unsafe.libc.jnr._
+import fs2.io.epoll.unsafe.libc
+
+import java.io.IOException
+
+import jnr.constants.platform.Errno;
+import jnr.constants.platform.OpenFlags;
+import jnr.constants.platform.Fcntl;
 
 class EpollSystemSuite extends EpollSuite {
 
-  test("sample suite") {
-    IO(42).assertEquals(42)
+  final class Pipe(
+      val readFd: Int,
+      val writeFd: Int,
+      val readHandle: FileDescriptorPollHandle,
+      val writeHandle: FileDescriptorPollHandle
+  ) {
+    def read(buf: Array[Byte], offset: Int, length: Int): IO[Unit] =
+      readHandle
+        .pollReadRec(())(_ =>
+          IO(guard(libc.jnr.read(readFd, byteToPtr(buf, offset), length.toLong).toInt))
+        )
+        .void
+
+    def write(buf: Array[Byte], offset: Int, length: Int): IO[Unit] =
+      writeHandle
+        .pollWriteRec(()) { _ =>
+          IO(guard(libc.jnr.write(writeFd, byteToPtr(buf, offset), length.toLong).toInt))
+        }
+        .void
+
+    private def guard(thunk: => Int): Either[Unit, Int] = {
+      val rtn = thunk
+      if (rtn < 0) {
+        val en = errno()
+        if (en == Errno.EAGAIN.intValue() || en == Errno.EWOULDBLOCK.intValue())
+          Left(())
+        else
+          throw new IOException(strerror(errno()))
+      } else
+        Right(rtn)
+    }
+  }
+
+  def getPoller: IO[Poller] =
+    IO.pollers.map(_.collectFirst { case epoll: Poller => epoll }).map(_.get)
+
+  def mkPipe: Resource[IO, Pipe] =
+    Resource
+      .make {
+        IO {
+          val fd = new Array[Int](2)
+          if (libc.jnr.pipe(fd) != 0)
+            throw new IOException(strerror(errno()))
+          (fd(0), fd(1))
+        }
+      } { case (readFd, writeFd) =>
+        IO {
+          libc.jnr.close(readFd)
+          libc.jnr.close(writeFd)
+          ()
+        }
+      }
+      .evalTap { case (readFd, writeFd) =>
+        IO {
+          if (
+            libc.jnr.fcntl(
+              readFd,
+              Fcntl.F_SETFL.intValue(),
+              OpenFlags.O_NONBLOCK.intValue()
+            ) != 0
+          )
+            throw new IOException(strerror(errno()))
+          if (
+            libc.jnr.fcntl(
+              writeFd,
+              Fcntl.F_SETFL.intValue(),
+              OpenFlags.O_NONBLOCK.intValue()
+            ) != 0
+          )
+            throw new IOException(strerror(errno()))
+        }
+      }
+      .flatMap { case (readFd, writeFd) =>
+        Resource.eval(FileDescriptorPoller.get).flatMap { poller =>
+          (
+            poller.registerFileDescriptor(readFd, true, false),
+            poller.registerFileDescriptor(writeFd, false, true)
+          ).mapN(new Pipe(readFd, writeFd, _, _))
+        }
+      }
+
+  test("FileDescriptorPoller notify read-ready events") {
+    mkPipe.use { pipe =>
+      (for {
+        buf <- IO(new Array[Byte](4))
+        _ <- pipe.write(Array[Byte](1, 2, 3), 0, 3).background.surround(pipe.read(buf, 0, 3))
+        _ <- pipe.write(Array[Byte](42), 0, 1).background.surround(pipe.read(buf, 3, 1))
+      } yield buf.toList).assertEquals(List[Byte](1, 2, 3, 42))
+    }
   }
 }


### PR DESCRIPTION
This PR provides a JVM implementation of `EpollSystem`, for the latest polling system published on cats-effect.

* Port the existing Native implementation for the JVM.
* We will also add the necessary FFI interface (we'll use JNR).


Similar work has been done previously on work fs2-io_uring project.

To avoid PR getting too large, I plan to address fs2 `Network` implementation in a separate PR.

